### PR TITLE
Bugfixes and improves in plugin-webpack-spa and plugin-webpack-babel

### DIFF
--- a/examples/react-typescript/package.json
+++ b/examples/react-typescript/package.json
@@ -15,7 +15,7 @@
     "@types/react": "16.9.23",
     "@types/react-dom": "16.9.5",
     "fork-ts-checker-webpack-plugin": "4.1.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.0-dev.20200319",
     "@zero-scripts/core": "^0.4.0",
     "@zero-scripts/plugin-webpack-spa": "^0.4.0",
     "@zero-scripts/plugin-webpack-react": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "1.19.1",
     "ts-jest": "25.2.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.0-dev.20200319",
     "utility-types": "3.10.0"
   },
   "husky": {

--- a/packages/plugin-webpack-babel/src/WebpackBabelPlugin.ts
+++ b/packages/plugin-webpack-babel/src/WebpackBabelPlugin.ts
@@ -35,11 +35,11 @@ export class WebpackBabelPlugin<
                       [
                         '@babel/preset-env',
                         {
-                          loose: true,
                           modules: false,
                           targets: { esmodules: true },
-                          useBuiltIns: 'usage',
-                          corejs: '3'
+                          useBuiltIns: 'entry',
+                          corejs: 3,
+                          exclude: ['transform-typeof-symbol']
                         }
                       ],
                       useTypescript && '@babel/preset-typescript',

--- a/packages/plugin-webpack-spa/package.json
+++ b/packages/plugin-webpack-spa/package.json
@@ -19,25 +19,23 @@
     "build"
   ],
   "dependencies": {
-    "@zero-scripts/webpack-config": "^0.4.0",
+    "@artemir/friendly-errors-webpack-plugin": "1.8.0",
     "@zero-scripts/core": "^0.4.0",
+    "@zero-scripts/webpack-config": "^0.4.0",
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "5.1.1",
-    "html-webpack-plugin": "4.0.0-beta.14",
-    "@artemir/friendly-errors-webpack-plugin": "1.8.0",
-    "script-ext-html-webpack-plugin": "2.1.4",
     "fastify": "2.12.1",
+    "html-webpack-plugin": "4.0.0-beta.14",
     "webpack": "4.42.0",
-    "webpack-dev-middleware": "4.0.0-rc.1",
+    "webpack-dev-middleware": "3.7.2",
     "webpack-hot-middleware": "2.25.0"
   },
   "devDependencies": {
-    "@zero-scripts/ts-config": "^0.4.0",
     "@types/clean-webpack-plugin": "0.1.3",
     "@types/copy-webpack-plugin": "5.0.0",
-    "@types/script-ext-html-webpack-plugin": "2.1.1",
     "@types/webpack-dev-middleware": "3.7.0",
-    "@types/webpack-hot-middleware": "2.25.0"
+    "@types/webpack-hot-middleware": "2.25.0",
+    "@zero-scripts/ts-config": "^0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,13 +2216,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/script-ext-html-webpack-plugin@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@types/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.1.tgz#dd2cf4dd342195a73fabafd4f194c3ab31d38d23"
-  integrity sha512-5zH1v99r68/d4Tq4xm9UGYKzb0CoEuPJUouTpZc3mEF7RwABfFZqhxRVAUaE9nXIgEce48GPBOMOu+peBLFfpw==
-  dependencies:
-    "@types/webpack" "*"
-
 "@types/set-value@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/set-value/-/set-value-2.0.0.tgz#63d386b103926dcf49b50e16e0f6dd49983046be"
@@ -5613,11 +5606,6 @@ fs-minipass@^2.0.0:
   dependencies:
     minipass "^3.0.0"
 
-fs-monkey@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.0.tgz#b1fe36b2d8a78463fd0b8fd1463b355952743bd0"
-  integrity sha512-nxkkzQ5Ga+ETriXxIof4TncyMSzrV9jFIF+kGN16nw5CiAdWAnG/2FgM7CHhRenW1EBiDx+r1tf/P78HGKCgnA==
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -7869,13 +7857,6 @@ mamacro@^0.0.3:
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
-map-age-cleaner@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -7911,21 +7892,6 @@ mdn-data@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
-
-mem@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-6.0.1.tgz#3f8ad1b0f8c4e00daf07f104e95b9d78131d7908"
-  integrity sha512-uIRYASflIsXqvKe+7aXbLrydaRzz4qiK6amqZDQI++eRtW3UoKtnDcGeCAOREgll7YMxO5E4VB9+3B0LFmy96g==
-  dependencies:
-    map-age-cleaner "^0.1.3"
-    mimic-fn "^3.0.0"
-
-memfs@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.1.2.tgz#2bb51600dacec67ed35677b1185abb708b7d2ad6"
-  integrity sha512-YubKuE+RGSdpZcRq2Nih8HcHj3LrqndsDFNB9IFjrgwzdM4eq+fImlDMfNm/HdRhYRkLdUecHGIpdz+wyrqlDg==
-  dependencies:
-    fs-monkey "1.0.0"
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -8057,12 +8023,17 @@ mime-db@1.43.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
-mime-types@^2.1.12, mime-types@^2.1.26, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
     mime-db "1.43.0"
+
+mime@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -8073,11 +8044,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
-  integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
 
 mini-css-extract-plugin@0.9.0:
   version "0.9.0"
@@ -8858,11 +8824,6 @@ osenv@0, osenv@^0.1.4, osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
-
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-each-series@^2.1.0:
   version "2.1.0"
@@ -10848,13 +10809,6 @@ schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4, schema-utils@^2.6
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-script-ext-html-webpack-plugin@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.4.tgz#7c309354e310bf78523e1b84ca96fd374ceb9880"
-  integrity sha512-7MAv3paAMfh9y2Rg+yQKp9jEGC5cEcmdge4EomRqri10qoczmliYEVPVNz0/5e9QQ202e05qDll9B8zZlY9N1g==
-  dependencies:
-    debug "^4.1.1"
-
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -12003,10 +11957,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.0-dev.20200319:
+  version "3.9.0-dev.20200319"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.0-dev.20200319.tgz#29215ad4bc35832c4a7b6b3679198ba1d916337b"
+  integrity sha512-t8BiBTDOeiN8BMSCLXFNNfEeMjm33JrLMGBtqq5NvY95KDxkDJiP2TsW4FnyRQicNpCJ8o9cQ3clrr0NtfYvJg==
 
 uglify-js@^3.1.4:
   version "3.8.0"
@@ -12316,16 +12270,16 @@ webpack-assets-manifest@3.1.1:
     tapable "^1.0.0"
     webpack-sources "^1.0.0"
 
-webpack-dev-middleware@4.0.0-rc.1:
-  version "4.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.1.tgz#445f85b8476505632dbbed99e84cb257c9d25a83"
-  integrity sha512-n7dww33POOkzM5MElcZ94K8Mnt0DRjgywWsVYSmD/LHY57M8lyLu9mj5nuCBSoYgAacudjGDW1phcInFi1BWQg==
+webpack-dev-middleware@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz#0019c3db716e3fa5cecbf64f2ab88a74bab331f3"
+  integrity sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==
   dependencies:
-    mem "^6.0.1"
-    memfs "^3.1.1"
-    mime-types "^2.1.26"
+    memory-fs "^0.4.1"
+    mime "^2.4.4"
+    mkdirp "^0.5.1"
     range-parser "^1.2.1"
-    schema-utils "^2.6.4"
+    webpack-log "^2.0.0"
 
 webpack-hot-middleware@2.25.0:
   version "2.25.0"


### PR DESCRIPTION
(plugin-webpack-spa) Revert back webpack-dev-middleware to 3.7.2. Fixes build crash on access to app in development mode (webpack/webpack-dev-middleware#602) and removes extra logs to console
(plugin-webpack-babel) Fix extra size of bundle in production mode, reduced ~44kb on the React example app
(plugin-webpack-spa) Plugins clean-webpack-plugin and copy-webpack-plugin now is used only in production mode
(plugin-webpack-spa) Remove script-ext-html-webpack-plugin