### PR TITLE
Make all tasks are classes

### DIFF
--- a/packages/core/src/cli/currentTask.ts
+++ b/packages/core/src/cli/currentTask.ts
@@ -1,0 +1,29 @@
+import { Task } from '../Task';
+
+type TaskMeta<
+  T extends Task<any, any>,
+  TArgs extends string[] = string[],
+  TOptions extends Record<string, unknown> = Record<string, unknown>
+> = {
+  args: TArgs;
+  options: TOptions;
+  instance: T;
+};
+
+type ExtractMeta<T extends Task<any, any>> = TaskMeta<
+  T,
+  Parameters<T['run']>[0],
+  Parameters<T['run']>[1]
+>;
+
+let taskMeta: TaskMeta<any, any> | undefined;
+
+export function getCurrentTaskMeta<T extends Task<any, any>>():
+  | ExtractMeta<T>
+  | undefined {
+  return taskMeta;
+}
+
+export function setCurrentTaskMeta(meta: TaskMeta<any>): void {
+  taskMeta = meta;
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,1 +1,2 @@
 export * from './run';
+export * from './currentTask';

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -6,6 +6,7 @@ import { PluginAPI, WorkspaceBeforeRunAPI } from '../api';
 import { readPackageJson } from '../utils/readPackageJson';
 import { readZeroScriptsOptions } from '../utils/readZeroScriptsOptions';
 import { WorkSpace } from '../WorkSpace';
+import { setCurrentTaskMeta } from './currentTask';
 import { getCLIMeta } from './getCLIMeta';
 import { getConfigurationMeta } from './getConfigurationMeta';
 import { pluginRegexp } from './pluginRegexp';
@@ -180,6 +181,12 @@ export async function run(argv: string[]): Promise<void> {
 
     const finalArgs = useCommonArgsAndOptions ? cliMeta.args : restArgs;
     const finalOptions = useCommonArgsAndOptions ? cliMeta.options : options;
+
+    setCurrentTaskMeta({
+      args: finalArgs,
+      options: finalOptions,
+      instance: task
+    });
 
     await task.run(finalArgs, finalOptions);
   }

--- a/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
@@ -1,0 +1,24 @@
+import webpack from 'webpack';
+
+import { Task } from '@zero-scripts/core';
+import { WebpackConfig } from '@zero-scripts/webpack-config';
+
+import { WebpackSpaPluginOptions } from '../WebpackSpaPluginOptions';
+
+export class TaskBuild extends Task<WebpackConfig, WebpackSpaPluginOptions> {
+  public run(args: string[], options: any): void | Promise<void> {
+    if (!this.isBound()) {
+      return this.printIfNotBound();
+    }
+
+    process.env.NODE_ENV = 'production';
+
+    const config = this.configBuilder.setIsDev(false).build();
+
+    const compiler = webpack(config);
+
+    compiler.run(err => {
+      if (err) throw err;
+    });
+  }
+}

--- a/packages/plugin-webpack-spa/src/tasks/TaskStart.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskStart.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import webpack from 'webpack';
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpackHotMiddleware from 'webpack-hot-middleware';
+
+import { Task } from '@zero-scripts/core';
+import { WebpackConfig } from '@zero-scripts/webpack-config';
+
+import { WebpackSpaPluginOptions } from '../WebpackSpaPluginOptions';
+
+type StartTaskOptions = {
+  port?: number;
+  smokeTest?: boolean;
+};
+
+export class TaskStart extends Task<WebpackConfig, WebpackSpaPluginOptions> {
+  public run(args: string[], options: StartTaskOptions): void | Promise<void> {
+    if (!this.isBound()) {
+      return this.printIfNotBound();
+    }
+
+    process.env.NODE_ENV = 'development';
+
+    const config = this.configBuilder
+      .setIsDev(true)
+      .addEntry(require.resolve('webpack-hot-middleware/client'))
+      .build();
+
+    const compiler = webpack(config);
+
+    const devServer = express();
+
+    devServer.use(webpackDevMiddleware(compiler));
+
+    devServer.use(
+      webpackHotMiddleware(compiler, {
+        log: false,
+        path: '/__webpack_hmr',
+        heartbeat: 10 * 1000
+      })
+    );
+
+    // for e2e tests
+    if (options.smokeTest) {
+      compiler.hooks.invalid.tap('WebpackSpaPlugin.smokeTest', () => {
+        process.exit(1);
+      });
+
+      devServer.get('/terminate-dev-server', () => {
+        process.exit(1);
+      });
+    }
+
+    devServer.listen(options.port || 8080);
+  }
+}

--- a/packages/plugin-webpack-spa/src/tasks/index.ts
+++ b/packages/plugin-webpack-spa/src/tasks/index.ts
@@ -1,0 +1,2 @@
+export * from './TaskBuild';
+export * from './TaskStart';


### PR DESCRIPTION
* All tasks now independent from concrete context.
* This allows to run the same task with different configuration builders and plugin options.
* Add the ability to get the current running task and its command-line arguments/parameters.