### PR TITLE
Common improvements

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,7 +18,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - run: pnpm i
-      - run: pnpm compile
+      - run: pnpm build
       - run: pnpm test
         env:
           CI: true

--- a/examples/react-astroturf/public/index.html
+++ b/examples/react-astroturf/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_PATH%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -12,7 +12,7 @@
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
   -->
-    <link rel="manifest" href="%PUBLIC_PATH%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/examples/react-less/public/index.html
+++ b/examples/react-less/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_PATH%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -12,7 +12,7 @@
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
   -->
-    <link rel="manifest" href="%PUBLIC_PATH%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/examples/react-sass/public/index.html
+++ b/examples/react-sass/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_PATH%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -12,7 +12,7 @@
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
   -->
-    <link rel="manifest" href="%PUBLIC_PATH%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/examples/react-typescript/public/index.html
+++ b/examples/react-typescript/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_PATH%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -12,7 +12,7 @@
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
   -->
-    <link rel="manifest" href="%PUBLIC_PATH%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/examples/react/public/index.html
+++ b/examples/react/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_PATH%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -12,7 +12,7 @@
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
   -->
-    <link rel="manifest" href="%PUBLIC_PATH%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/package.json
+++ b/package.json
@@ -6,16 +6,15 @@
     "examples/*"
   ],
   "scripts": {
-    "clean": "tsc -b packages --clean",
-    "compile": "tsc -b packages",
-    "lint-staged": "lint-staged",
-    "prepublishOnly": "run-s clean compile",
+    "build": "tsc -b packages",
+    "prepublishOnly": "run-s remove-build build",
+    "remove-build": "rimraf packages/*/build packages/*/*.tsbuildinfo",
     "test": "jest",
     "watch": "tsc -b packages --watch"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pnpm lint-staged"
+      "pre-commit": "pnpx lint-staged"
     }
   },
   "lint-staged": {
@@ -46,6 +45,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "2.1.0",
     "prettier-plugin-packagejson": "2.2.5",
+    "rimraf": "^3.0.2",
     "ts-jest": "26.2.0",
     "typescript": "4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "2.1.0",
     "prettier-plugin-packagejson": "2.2.5",
-    "rimraf": "^3.0.2",
+    "rimraf": "3.0.2",
     "ts-jest": "26.2.0",
     "typescript": "4.0.2"
   }

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -38,18 +38,7 @@ function getPluginPackageList(
       Object.keys(pkg?.devDependencies || {})
     );
 
-    const filteredDevDependencies = devDependencies.filter(pkgName =>
-      pluginRegexp.test(pkgName)
-    );
-
-    // eslint-disable-next-line no-console
-    console.log(
-      `Workspace option is not set, load plugins from devDependencies: ${filteredDevDependencies.join(
-        ', '
-      )}`
-    );
-
-    return filteredDevDependencies;
+    return devDependencies.filter(pkgName => pluginRegexp.test(pkgName));
   }
 
   if (meta.workspaceType === WorkspaceConfigurationType.MAPPED_ARRAYS) {

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -6,7 +6,6 @@ import { AbstractPlugin } from '../AbstractPlugin';
 import { ApplyContext, BeforeRunContext } from '../context';
 import { readPackageJson } from '../utils/readPackageJson';
 import { readZeroScriptsOptions } from '../utils/readZeroScriptsOptions';
-import { resolvePath } from '../utils/resolvePath';
 import { WorkSpace } from '../WorkSpace';
 import { setCurrentTaskMeta } from './currentTask';
 import { getCLIMeta } from './getCLIMeta';
@@ -143,9 +142,7 @@ export async function run(argv: string[]): Promise<void> {
     return plugin;
   });
 
-  dotEnv.config({
-    path: resolvePath('.env')
-  });
+  dotEnv.config();
 
   const applyContext = new ApplyContext(workSpaceInstance);
 

--- a/packages/plugin-webpack-spa/package.json
+++ b/packages/plugin-webpack-spa/package.json
@@ -28,7 +28,7 @@
     "build"
   ],
   "dependencies": {
-    "@artemir/friendly-errors-webpack-plugin": "2.0.1",
+    "@artemir/friendly-errors-webpack-plugin": "2.0.2",
     "@npmcli/ci-detect": "1.3.0",
     "@zero-scripts/core": "workspace:*",
     "@zero-scripts/webpack-config": "workspace:*",

--- a/packages/plugin-webpack-spa/package.json
+++ b/packages/plugin-webpack-spa/package.json
@@ -28,7 +28,7 @@
     "build"
   ],
   "dependencies": {
-    "@artemir/friendly-errors-webpack-plugin": "1.8.0",
+    "@artemir/friendly-errors-webpack-plugin": "2.0.1",
     "@npmcli/ci-detect": "1.3.0",
     "@zero-scripts/core": "workspace:*",
     "@zero-scripts/webpack-config": "workspace:*",

--- a/packages/plugin-webpack-spa/src/WebpackSpaPlugin.ts
+++ b/packages/plugin-webpack-spa/src/WebpackSpaPlugin.ts
@@ -1,3 +1,4 @@
+import { FriendlyErrorsWebpackPlugin } from '@artemir/friendly-errors-webpack-plugin';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import { HotAcceptPlugin } from 'hot-accept-webpack-plugin';
@@ -16,9 +17,6 @@ import { WebpackConfig } from '@zero-scripts/webpack-config';
 
 import { TaskStart, TaskBuild, TaskWatch } from './tasks';
 import { WebpackSpaPluginOptions } from './WebpackSpaPluginOptions';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const FriendlyErrorsPlugin = require('@artemir/friendly-errors-webpack-plugin');
 
 @ReadOptions(WebpackSpaPluginOptions, 'plugin-webpack-spa')
 export class WebpackSpaPlugin extends AbstractPlugin<WebpackSpaPluginOptions> {
@@ -64,7 +62,7 @@ export class WebpackSpaPlugin extends AbstractPlugin<WebpackSpaPluginOptions> {
 
           if (isStartTask) {
             modifications.insertPlugin(
-              new FriendlyErrorsPlugin({
+              new FriendlyErrorsWebpackPlugin({
                 compilationSuccessInfo: {
                   messages: [
                     'Your application is available at http://localhost:' +
@@ -91,7 +89,7 @@ export class WebpackSpaPlugin extends AbstractPlugin<WebpackSpaPluginOptions> {
             modifications.insertPlugin(new CleanWebpackPlugin());
 
             modifications.insertPlugin(
-              new FriendlyErrorsPlugin({
+              new FriendlyErrorsWebpackPlugin({
                 compilationSuccessInfo: {
                   messages: [
                     `Your application successfully built and available at ${paths.build
@@ -105,7 +103,7 @@ export class WebpackSpaPlugin extends AbstractPlugin<WebpackSpaPluginOptions> {
 
           if (isWatchTask) {
             modifications.insertPlugin(
-              new FriendlyErrorsPlugin({
+              new FriendlyErrorsWebpackPlugin({
                 compilationSuccessInfo: {
                   messages: [
                     `Your application successfully built and available at ${paths.build

--- a/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
@@ -1,3 +1,4 @@
+import { output } from '@artemir/friendly-errors-webpack-plugin';
 import webpack from 'webpack';
 
 import { Task } from '@zero-scripts/core';
@@ -19,6 +20,9 @@ export class TaskBuild extends Task {
     const config = this.configBuilder.setIsDev(false).build();
 
     const compiler = webpack(config);
+
+    output.clearConsole();
+    output.title('info', 'WAIT', 'Compiling...');
 
     compiler.run(err => {
       if (err) throw err;

--- a/packages/plugin-webpack-spa/src/tasks/TaskStart.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskStart.ts
@@ -1,3 +1,4 @@
+import { output } from '@artemir/friendly-errors-webpack-plugin';
 import express from 'express';
 import open from 'open';
 import webpack from 'webpack';
@@ -75,6 +76,9 @@ export class TaskStart extends Task {
     }
 
     devServer.use(express.static(configOptions.paths.public));
+
+    output.clearConsole();
+    output.title('info', 'WAIT', 'Starting the development server...');
 
     devServer.listen(port);
   }

--- a/packages/plugin-webpack-spa/src/tasks/TaskWatch.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskWatch.ts
@@ -1,3 +1,4 @@
+import { output } from '@artemir/friendly-errors-webpack-plugin';
 import webpack from 'webpack';
 
 import { Task } from '@zero-scripts/core';
@@ -33,6 +34,9 @@ export class TaskWatch extends Task {
         process.exit(1);
       });
     }
+
+    output.clearConsole();
+    output.title('info', 'WAIT', 'Compiling...');
 
     compiler.watch(
       {

--- a/packages/webpack-config/src/WebpackConfigOptions.ts
+++ b/packages/webpack-config/src/WebpackConfigOptions.ts
@@ -23,7 +23,7 @@ export class WebpackConfigOptions extends AbstractOptionsContainer<
     indexJs: 'src/index',
     indexHtml: 'public/index.html',
     public: 'public',
-    publicPath: process.env.PUBLIC_PATH || '',
+    publicUrlOrPath: process.env.PUBLIC_URL || '',
     tsConfig: 'tsconfig.json'
   };
 

--- a/packages/webpack-config/src/createWebpackConfiguration.ts
+++ b/packages/webpack-config/src/createWebpackConfiguration.ts
@@ -9,13 +9,20 @@ import { ExtractOptions } from '@zero-scripts/core';
 
 import { WebpackConfigOptions } from './WebpackConfigOptions';
 
+type ConfigurationWithLog = Configuration & {
+  infrastructureLogging?: {
+    level?: 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose';
+    debug?: boolean;
+  };
+};
+
 export function createWebpackConfiguration({
   isDev,
   paths,
   additionalEntry,
   useSourceMap,
   moduleFileExtensions
-}: ExtractOptions<WebpackConfigOptions>): Configuration {
+}: ExtractOptions<WebpackConfigOptions>): ConfigurationWithLog {
   return {
     mode: isDev ? 'development' : 'production',
     entry: [paths.indexJs, ...additionalEntry],
@@ -84,5 +91,5 @@ export function createWebpackConfiguration({
     infrastructureLogging: {
       level: 'none'
     }
-  } as Configuration;
+  };
 }

--- a/packages/webpack-config/src/createWebpackConfiguration.ts
+++ b/packages/webpack-config/src/createWebpackConfiguration.ts
@@ -80,9 +80,9 @@ export function createWebpackConfiguration({
       tls: 'empty',
       child_process: 'empty'
     },
-    stats: 'errors-only',
+    stats: 'none',
     infrastructureLogging: {
-      level: 'error'
+      level: 'none'
     }
   } as Configuration;
 }

--- a/packages/webpack-config/src/createWebpackConfiguration.ts
+++ b/packages/webpack-config/src/createWebpackConfiguration.ts
@@ -30,7 +30,7 @@ export function createWebpackConfiguration({
     output: {
       path: paths.build,
       filename: isDev ? 'js/[name].js' : 'js/[name].[contenthash:8].js',
-      publicPath: paths.publicPath,
+      publicPath: paths.publicUrlOrPath,
       chunkFilename: isDev
         ? 'js/[name].chunk.js'
         : 'js/[name].[contenthash:8].chunk.js',
@@ -74,9 +74,9 @@ export function createWebpackConfiguration({
         output: 'asset-manifest.json'
       }),
       new InterpolateHtmlPlugin({
-        PUBLIC_PATH: paths.publicPath.endsWith('/')
-          ? paths.publicPath.slice(0, -1)
-          : paths.publicPath
+        PUBLIC_URL: paths.publicUrlOrPath.endsWith('/')
+          ? paths.publicUrlOrPath.slice(0, -1)
+          : paths.publicUrlOrPath
       })
     ],
     node: {

--- a/packages/webpack-config/src/resolvePaths.ts
+++ b/packages/webpack-config/src/resolvePaths.ts
@@ -11,7 +11,7 @@ export function resolvePaths(
   return {
     src: resolvePath(paths.src),
     root: resolvePath(paths.root),
-    publicPath: isDevelopment ? '/' : paths.publicPath,
+    publicUrlOrPath: isDevelopment ? '/' : paths.publicUrlOrPath,
     public: resolvePath(paths.public),
     build: resolvePath(paths.build),
     indexHtml: resolvePath(paths.indexHtml),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,7 +381,7 @@ importers:
       webpack: ^4.43.0
   packages/plugin-webpack-spa:
     dependencies:
-      '@artemir/friendly-errors-webpack-plugin': 1.8.0_webpack@4.43.0
+      '@artemir/friendly-errors-webpack-plugin': 2.0.1_webpack@4.43.0
       '@npmcli/ci-detect': 1.3.0
       '@zero-scripts/core': 'link:../core'
       '@zero-scripts/webpack-config': 'link:../webpack-config'
@@ -401,7 +401,7 @@ importers:
       '@types/webpack-dev-middleware': 3.7.1
       '@types/webpack-hot-middleware': 2.25.3
     specifiers:
-      '@artemir/friendly-errors-webpack-plugin': 1.8.0
+      '@artemir/friendly-errors-webpack-plugin': 2.0.1
       '@npmcli/ci-detect': 1.3.0
       '@types/copy-webpack-plugin': 6.0.0
       '@types/express': 4.17.7
@@ -465,17 +465,20 @@ importers:
       webpack-assets-manifest: 3.1.1
 lockfileVersion: 5.1
 packages:
-  /@artemir/friendly-errors-webpack-plugin/1.8.0_webpack@4.43.0:
+  /@artemir/friendly-errors-webpack-plugin/2.0.1_webpack@4.43.0:
     dependencies:
-      chalk: 1.1.3
+      chalk: 2.4.2
       error-stack-parser: 2.0.6
       string-width: 2.1.1
+      strip-ansi: 5.2.0
       webpack: 4.43.0_webpack@4.43.0
     dev: false
+    engines:
+      node: '>=8.0.0'
     peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
+      webpack: ^4.0.0
     resolution:
-      integrity: sha512-qd7eTc9YcZsWxShoZLUjCMuUzZ/prvsSkxgk+KZ5aSw/ND0bjroXcSQMxs6pXniHL1e8SQs/wPiWnNXfdwmJ7w==
+      integrity: sha512-Xgc6P3/tmzM6jPu8HlpZWYvFuQY1Zqp42GMOOJJVmlCnSIsmi+tc9WcHQouTR8EMuEp/mrdvV81MR1NE791BtQ==
   /@babel/code-frame/7.10.4:
     dependencies:
       '@babel/highlight': 7.10.4
@@ -3520,7 +3523,7 @@ packages:
   /chalk/4.1.0:
     dependencies:
       ansi-styles: 4.2.1
-      supports-color: 7.1.0
+      supports-color: 7.2.0
     engines:
       node: '>=10'
     resolution:
@@ -4736,7 +4739,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.1
       chalk: 4.1.0
-      eslint-rule-docs: 1.1.199
+      eslint-rule-docs: 1.1.208
       log-symbols: 4.0.0
       plur: 4.0.0
       string-width: 4.2.0
@@ -4877,9 +4880,9 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-txbo090buDeyV0ugF3YMWrzLIUqpYTsWSDZV9xLSmExE1P/Kmgg9++PD931r+KEWS66O1c9R4srLVVHmeHpoAg==
-  /eslint-rule-docs/1.1.199:
+  /eslint-rule-docs/1.1.208:
     resolution:
-      integrity: sha512-0jXhQ2JLavUsV/8HVFrBSHL4EM17cl0veZHAVcF1HOEoPdrr09huADK9/L7CbsqP4tMJy9FG23neUEDH8W/Mmg==
+      integrity: sha512-ynDZiU5BZ4lligcEFby+hebqdM+esbHDkbvu59anIzVoMiU+axexUfPaP0dwGASEodHDQBVZbk62ImMluvXBsA==
   /eslint-scope/4.0.3:
     dependencies:
       esrecurse: 4.2.1
@@ -10696,10 +10699,17 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  /supports-color/7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   /supports-hyperlinks/2.1.0:
     dependencies:
       has-flag: 4.0.0
-      supports-color: 7.1.0
+      supports-color: 7.2.0
     engines:
       node: '>=8'
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       npm-run-all: 4.1.5
       prettier: 2.1.0
       prettier-plugin-packagejson: 2.2.5_prettier@2.1.0
+      rimraf: 3.0.2
       ts-jest: 26.2.0_jest@26.4.2+typescript@4.0.2
       typescript: 4.0.2
     specifiers:
@@ -42,6 +43,7 @@ importers:
       npm-run-all: 4.1.5
       prettier: 2.1.0
       prettier-plugin-packagejson: 2.2.5
+      rimraf: ^3.0.2
       ts-jest: 26.2.0
       typescript: 4.0.2
   examples/react:
@@ -2638,6 +2640,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  /aggregate-error/3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
   /ajv-errors/1.0.1_ajv@6.12.3:
     dependencies:
       ajv: 6.12.3
@@ -7003,6 +7014,10 @@ packages:
   /json-parse-better-errors/1.0.2:
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+  /json-parse-even-better-errors/2.3.1:
+    dev: true
+    resolution:
+      integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
   /json-schema-traverse/0.4.1:
     resolution:
       integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
@@ -8230,7 +8245,7 @@ packages:
       integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
   /p-map/3.0.0:
     dependencies:
-      aggregate-error: 3.0.1
+      aggregate-error: 3.1.0
     dev: true
     engines:
       node: '>=8'
@@ -8315,6 +8330,17 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  /parse-json/5.1.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.1.6
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   /parse5-htmlparser2-tree-adapter/5.1.1:
     dependencies:
       parse5: 5.1.1
@@ -9543,7 +9569,7 @@ packages:
     dependencies:
       '@types/normalize-package-data': 2.4.0
       normalize-package-data: 2.5.0
-      parse-json: 5.0.0
+      parse-json: 5.1.0
       type-fest: 0.6.0
     dev: true
     engines:
@@ -10342,7 +10368,7 @@ packages:
   /spdx-correct/3.1.1:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.5
+      spdx-license-ids: 3.0.6
     resolution:
       integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
   /spdx-exceptions/2.3.0:
@@ -10351,12 +10377,12 @@ packages:
   /spdx-expression-parse/3.0.1:
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.5
+      spdx-license-ids: 3.0.6
     resolution:
       integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  /spdx-license-ids/3.0.5:
+  /spdx-license-ids/3.0.6:
     resolution:
-      integrity: sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+      integrity: sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
   /split-string/3.1.0:
     dependencies:
       extend-shallow: 3.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,7 +381,7 @@ importers:
       webpack: ^4.43.0
   packages/plugin-webpack-spa:
     dependencies:
-      '@artemir/friendly-errors-webpack-plugin': 2.0.1_webpack@4.43.0
+      '@artemir/friendly-errors-webpack-plugin': 2.0.2_webpack@4.43.0
       '@npmcli/ci-detect': 1.3.0
       '@zero-scripts/core': 'link:../core'
       '@zero-scripts/webpack-config': 'link:../webpack-config'
@@ -401,7 +401,7 @@ importers:
       '@types/webpack-dev-middleware': 3.7.1
       '@types/webpack-hot-middleware': 2.25.3
     specifiers:
-      '@artemir/friendly-errors-webpack-plugin': 2.0.1
+      '@artemir/friendly-errors-webpack-plugin': 2.0.2
       '@npmcli/ci-detect': 1.3.0
       '@types/copy-webpack-plugin': 6.0.0
       '@types/express': 4.17.7
@@ -465,7 +465,7 @@ importers:
       webpack-assets-manifest: 3.1.1
 lockfileVersion: 5.1
 packages:
-  /@artemir/friendly-errors-webpack-plugin/2.0.1_webpack@4.43.0:
+  /@artemir/friendly-errors-webpack-plugin/2.0.2_webpack@4.43.0:
     dependencies:
       chalk: 2.4.2
       error-stack-parser: 2.0.6
@@ -478,7 +478,7 @@ packages:
     peerDependencies:
       webpack: ^4.0.0
     resolution:
-      integrity: sha512-Xgc6P3/tmzM6jPu8HlpZWYvFuQY1Zqp42GMOOJJVmlCnSIsmi+tc9WcHQouTR8EMuEp/mrdvV81MR1NE791BtQ==
+      integrity: sha512-XWKtN2SkvlWMJ3c/VLte7AdBeb3Fn+xUFZbk8Dl7ckGXunzi2Mb13Vpn2PfzswEUVEMM1QxkjDeLzzcxth2Ovw==
   /@babel/code-frame/7.10.4:
     dependencies:
       '@babel/highlight': 7.10.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
       npm-run-all: 4.1.5
       prettier: 2.1.0
       prettier-plugin-packagejson: 2.2.5
-      rimraf: ^3.0.2
+      rimraf: 3.0.2
       ts-jest: 26.2.0
       typescript: 4.0.2
   examples/react:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,13 @@
     "strict": true,
     "esModuleInterop": true,
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "sourceMap": true,
     "composite": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,
-    "incremental": true
+    "incremental": true,
+    "pretty": true,
+    "noUnusedLocals": true
   }
 }


### PR DESCRIPTION
- [x] Remove extra text from ESLint warnings: `Module Warning (from ./node_modules/eslint-loader/dist/cjs.js):`
- [x] Add message `Starting the development server...` for start task
- [x] Remove extra warning `Workspace option is not set, load plugins from devDependencies:...`
- [x] Do not emit source maps for d.ts files in publish build
- [x] Rename `PUBLIC_PATH` to `PUBLIC_URL`
- [x] Add `Compiling...` message for watch and build tasks


Closes #633