### PR TITLE
Fix Babel env preset config for deps

### DIFF
--- a/packages/plugin-webpack-babel/package.json
+++ b/packages/plugin-webpack-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-scripts/plugin-webpack-babel",
-  "version": "1.0.0-alfa.6",
+  "version": "1.0.0-alfa.7",
   "description": "Adds processing JavaScript code with Babel",
   "keywords": [
     "webpack",

--- a/packages/plugin-webpack-babel/src/WebpackBabelPlugin.ts
+++ b/packages/plugin-webpack-babel/src/WebpackBabelPlugin.ts
@@ -98,7 +98,17 @@ export class WebpackBabelPlugin extends AbstractPlugin<
                   babelrc: false,
                   configFile: false,
                   compact: false,
-                  presets: [[rr('@babel/preset-env'), { loose: true }]],
+                  presets: [
+                    [
+                      rr('@babel/preset-env'),
+                      {
+                        useBuiltIns: 'entry',
+                        corejs: 3,
+                        exclude: ['transform-typeof-symbol'],
+                        loose: true
+                      }
+                    ]
+                  ],
                   cacheDirectory: true,
                   cacheCompression: !isDev,
                   sourceMaps: false


### PR DESCRIPTION
This inconsistency can cause "regeneratorRuntime is not defined" error with some dependencies