### PR TITLE
Add `--json` option to `build` task which generate bundle stats

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v1.2.0
+      - uses: pnpm/action-setup@v1.2.1
         with:
-          version: 5.9.3
+          version: 5.13.1
       - name: Retrieve content-addressable store from cache
         uses: actions/cache@v2
         with:

--- a/packages/plugin-webpack-spa/package.json
+++ b/packages/plugin-webpack-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-scripts/plugin-webpack-spa",
-  "version": "1.0.0-alfa.9",
+  "version": "1.0.0-alfa.10",
   "keywords": [
     "webpack",
     "config",

--- a/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
+++ b/packages/plugin-webpack-spa/src/tasks/TaskBuild.ts
@@ -1,10 +1,16 @@
 import { output } from '@artemir/friendly-errors-webpack-plugin';
-import webpack from 'webpack';
+import { writeFileSync } from 'fs';
+import webpack, { Compiler } from 'webpack';
 
 import { Task } from '@zero-scripts/core';
 import { WebpackConfig } from '@zero-scripts/webpack-config';
 
+import { getStatsOptions } from '../utils/getStatsOptions';
 import { WebpackSpaPluginOptions } from '../WebpackSpaPluginOptions';
+
+type BuildTaskOptions = {
+  json?: boolean | string;
+};
 
 export class TaskBuild extends Task {
   constructor(
@@ -14,18 +20,50 @@ export class TaskBuild extends Task {
     super('build');
   }
 
-  public run(): void | Promise<void> {
+  public run(args: string[], options: BuildTaskOptions): void | Promise<void> {
     process.env.NODE_ENV = 'production';
 
     const config = this.configBuilder.setIsDev(false).build();
+
+    if (options.json) {
+      config.stats = 'verbose';
+    }
 
     const compiler = webpack(config);
 
     output.clearConsole();
     output.title('info', 'WAIT', 'Compiling...');
 
-    compiler.run(err => {
+    compiler.run((err, stats) => {
       if (err) throw err;
+
+      const getStatsOptionsFromCompiler = (compiler: Compiler) =>
+        getStatsOptions(compiler.options ? compiler.options.stats : undefined);
+
+      const foundStats = getStatsOptionsFromCompiler(compiler);
+
+      if (options.json === true) {
+        process.stdout.write(
+          JSON.stringify(stats.toJson(foundStats), null, 2) + '\n'
+        );
+      }
+
+      if (typeof options.json === 'string') {
+        const JSONStats = JSON.stringify(stats.toJson(foundStats), null, 2);
+
+        try {
+          writeFileSync(options.json, JSONStats);
+
+          console.log();
+          output.info(
+            `Stats are successfully stored as json to ${options.json}`
+          );
+        } catch (error) {
+          console.log(error);
+
+          process.exit(2);
+        }
+      }
     });
   }
 }

--- a/packages/plugin-webpack-spa/src/utils/getStatsOptions.ts
+++ b/packages/plugin-webpack-spa/src/utils/getStatsOptions.ts
@@ -1,0 +1,16 @@
+import webpack from 'webpack';
+
+import Stats = webpack.Options.Stats;
+
+export function getStatsOptions(stats?: Stats): Stats | undefined {
+  // TODO remove after drop webpack@4
+  if (webpack.Stats && webpack.Stats.presetToOptions) {
+    if (!stats) {
+      stats = {};
+    } else if (typeof stats === 'boolean' || typeof stats === 'string') {
+      stats = webpack.Stats.presetToOptions(stats);
+    }
+  }
+
+  return stats;
+}


### PR DESCRIPTION
For example, `run build --json` will print stats in stdout
For example, `run build --json stats.json` will write stats to `stats.json` file

Scope: plugin-webpack-spa